### PR TITLE
Update dependencies NJsonSchema, NSwag and DotLiquid

### DIFF
--- a/src/Unchase.OpenAPI.ConnectedService.csproj
+++ b/src/Unchase.OpenAPI.ConnectedService.csproj
@@ -143,8 +143,8 @@
     <Analyzer Include="packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.168\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="DotLiquid, Version=2.0.314.0, Culture=neutral, PublicKeyToken=82e46016ecf9f07c, processorArchitecture=MSIL">
-      <HintPath>packages\DotLiquid.2.0.314\lib\net45\DotLiquid.dll</HintPath>
+    <Reference Include="DotLiquid, Version=2.0.385.0, Culture=neutral, PublicKeyToken=82e46016ecf9f07c, processorArchitecture=MSIL">
+      <HintPath>packages\DotLiquid.2.0.385\lib\net45\DotLiquid.dll</HintPath>
     </Reference>
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>packages\VSSDK.DTE.7.0.4\lib\net20\envdte.dll</HintPath>
@@ -457,53 +457,53 @@
       <HintPath>packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NJsonSchema, Version=10.3.4.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>packages\NJsonSchema.10.3.4\lib\net45\NJsonSchema.dll</HintPath>
+    <Reference Include="NJsonSchema, Version=10.3.8.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>packages\NJsonSchema.10.3.8\lib\net45\NJsonSchema.dll</HintPath>
     </Reference>
-    <Reference Include="NJsonSchema.CodeGeneration, Version=10.3.4.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>packages\NJsonSchema.CodeGeneration.10.3.4\lib\net451\NJsonSchema.CodeGeneration.dll</HintPath>
+    <Reference Include="NJsonSchema.CodeGeneration, Version=10.3.8.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>packages\NJsonSchema.CodeGeneration.10.3.8\lib\net451\NJsonSchema.CodeGeneration.dll</HintPath>
     </Reference>
-    <Reference Include="NJsonSchema.CodeGeneration.CSharp, Version=10.3.4.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>packages\NJsonSchema.CodeGeneration.CSharp.10.3.4\lib\net451\NJsonSchema.CodeGeneration.CSharp.dll</HintPath>
+    <Reference Include="NJsonSchema.CodeGeneration.CSharp, Version=10.3.8.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>packages\NJsonSchema.CodeGeneration.CSharp.10.3.8\lib\net451\NJsonSchema.CodeGeneration.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="NJsonSchema.CodeGeneration.TypeScript, Version=10.3.4.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>packages\NJsonSchema.CodeGeneration.TypeScript.10.3.4\lib\net451\NJsonSchema.CodeGeneration.TypeScript.dll</HintPath>
+    <Reference Include="NJsonSchema.CodeGeneration.TypeScript, Version=10.3.8.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>packages\NJsonSchema.CodeGeneration.TypeScript.10.3.8\lib\net451\NJsonSchema.CodeGeneration.TypeScript.dll</HintPath>
     </Reference>
-    <Reference Include="NJsonSchema.Yaml, Version=10.3.4.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>packages\NJsonSchema.Yaml.10.3.4\lib\net45\NJsonSchema.Yaml.dll</HintPath>
+    <Reference Include="NJsonSchema.Yaml, Version=10.3.8.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>packages\NJsonSchema.Yaml.10.3.8\lib\net45\NJsonSchema.Yaml.dll</HintPath>
     </Reference>
-    <Reference Include="NSwag.Annotations, Version=13.10.2.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
-      <HintPath>packages\NSwag.Annotations.13.10.2\lib\net45\NSwag.Annotations.dll</HintPath>
+    <Reference Include="NSwag.Annotations, Version=13.10.6.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
+      <HintPath>packages\NSwag.Annotations.13.10.6\lib\net45\NSwag.Annotations.dll</HintPath>
     </Reference>
-    <Reference Include="NSwag.AssemblyLoader, Version=13.10.2.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
-      <HintPath>packages\NSwag.AssemblyLoader.13.10.2\lib\net451\NSwag.AssemblyLoader.dll</HintPath>
+    <Reference Include="NSwag.AssemblyLoader, Version=13.10.6.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
+      <HintPath>packages\NSwag.AssemblyLoader.13.10.6\lib\net451\NSwag.AssemblyLoader.dll</HintPath>
     </Reference>
-    <Reference Include="NSwag.CodeGeneration, Version=13.10.2.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
-      <HintPath>packages\NSwag.CodeGeneration.13.10.2\lib\net451\NSwag.CodeGeneration.dll</HintPath>
+    <Reference Include="NSwag.CodeGeneration, Version=13.10.6.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
+      <HintPath>packages\NSwag.CodeGeneration.13.10.6\lib\net451\NSwag.CodeGeneration.dll</HintPath>
     </Reference>
-    <Reference Include="NSwag.CodeGeneration.CSharp, Version=13.10.2.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
-      <HintPath>packages\NSwag.CodeGeneration.CSharp.13.10.2\lib\net451\NSwag.CodeGeneration.CSharp.dll</HintPath>
+    <Reference Include="NSwag.CodeGeneration.CSharp, Version=13.10.6.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
+      <HintPath>packages\NSwag.CodeGeneration.CSharp.13.10.6\lib\net451\NSwag.CodeGeneration.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="NSwag.CodeGeneration.TypeScript, Version=13.10.2.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
-      <HintPath>packages\NSwag.CodeGeneration.TypeScript.13.10.2\lib\net451\NSwag.CodeGeneration.TypeScript.dll</HintPath>
+    <Reference Include="NSwag.CodeGeneration.TypeScript, Version=13.10.6.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
+      <HintPath>packages\NSwag.CodeGeneration.TypeScript.13.10.6\lib\net451\NSwag.CodeGeneration.TypeScript.dll</HintPath>
     </Reference>
-    <Reference Include="NSwag.Commands, Version=13.10.2.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
-      <HintPath>packages\NSwag.Commands.13.10.2\lib\net461\NSwag.Commands.dll</HintPath>
+    <Reference Include="NSwag.Commands, Version=13.10.6.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
+      <HintPath>packages\NSwag.Commands.13.10.6\lib\net461\NSwag.Commands.dll</HintPath>
     </Reference>
-    <Reference Include="NSwag.Core, Version=13.10.2.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
-      <HintPath>packages\NSwag.Core.13.10.2\lib\net45\NSwag.Core.dll</HintPath>
+    <Reference Include="NSwag.Core, Version=13.10.6.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
+      <HintPath>packages\NSwag.Core.13.10.6\lib\net45\NSwag.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NSwag.Core.Yaml, Version=13.10.2.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
-      <HintPath>packages\NSwag.Core.Yaml.13.10.2\lib\net45\NSwag.Core.Yaml.dll</HintPath>
+    <Reference Include="NSwag.Core.Yaml, Version=13.10.6.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
+      <HintPath>packages\NSwag.Core.Yaml.13.10.6\lib\net45\NSwag.Core.Yaml.dll</HintPath>
     </Reference>
-    <Reference Include="NSwag.Generation, Version=13.10.2.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
-      <HintPath>packages\NSwag.Generation.13.10.2\lib\net45\NSwag.Generation.dll</HintPath>
+    <Reference Include="NSwag.Generation, Version=13.10.6.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
+      <HintPath>packages\NSwag.Generation.13.10.6\lib\net45\NSwag.Generation.dll</HintPath>
     </Reference>
-    <Reference Include="NSwag.Generation.AspNetCore, Version=13.10.2.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
-      <HintPath>packages\NSwag.Generation.AspNetCore.13.10.2\lib\net451\NSwag.Generation.AspNetCore.dll</HintPath>
+    <Reference Include="NSwag.Generation.AspNetCore, Version=13.10.6.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
+      <HintPath>packages\NSwag.Generation.AspNetCore.13.10.6\lib\net451\NSwag.Generation.AspNetCore.dll</HintPath>
     </Reference>
-    <Reference Include="NSwag.Generation.WebApi, Version=13.10.2.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
-      <HintPath>packages\NSwag.Generation.WebApi.13.10.2\lib\net45\NSwag.Generation.WebApi.dll</HintPath>
+    <Reference Include="NSwag.Generation.WebApi, Version=13.10.6.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
+      <HintPath>packages\NSwag.Generation.WebApi.13.10.6\lib\net45\NSwag.Generation.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="NSwag.SwaggerGeneration, Version=12.3.1.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
       <HintPath>packages\NSwag.SwaggerGeneration.12.3.1\lib\net45\NSwag.SwaggerGeneration.dll</HintPath>

--- a/src/app.config
+++ b/src/app.config
@@ -88,15 +88,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NSwag.Core" publicKeyToken="c2d88086e098d109" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.10.2.0" newVersion="13.10.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.10.6.0" newVersion="13.10.6.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NJsonSchema" publicKeyToken="c2f9c3bdfae56102" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.3.4.0" newVersion="10.3.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.3.8.0" newVersion="10.3.8.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NJsonSchema.CodeGeneration" publicKeyToken="c2f9c3bdfae56102" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.24.0" newVersion="10.0.24.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.3.8.0" newVersion="10.3.8.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NSwag.CodeGeneration" publicKeyToken="c2d88086e098d109" culture="neutral" />
@@ -285,6 +285,18 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.AspNetCore" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NJsonSchema.CodeGeneration.CSharp" publicKeyToken="c2f9c3bdfae56102" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.3.8.0" newVersion="10.3.8.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NJsonSchema.CodeGeneration.TypeScript" publicKeyToken="c2f9c3bdfae56102" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.3.8.0" newVersion="10.3.8.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NJsonSchema.Yaml" publicKeyToken="c2f9c3bdfae56102" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.3.8.0" newVersion="10.3.8.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotLiquid" version="2.0.314" targetFramework="net461" />
+  <package id="DotLiquid" version="2.0.385" targetFramework="net461" />
   <package id="EnvDTE" version="8.0.2" targetFramework="net461" />
   <package id="EnvDTE80" version="8.0.3" targetFramework="net461" />
   <package id="Microsoft.AspNetCore" version="2.2.0" targetFramework="net461" />
@@ -109,22 +109,22 @@
   <package id="NConsole" version="3.9.6519.30868" targetFramework="net461" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
-  <package id="NJsonSchema" version="10.3.4" targetFramework="net461" />
-  <package id="NJsonSchema.CodeGeneration" version="10.3.4" targetFramework="net461" />
-  <package id="NJsonSchema.CodeGeneration.CSharp" version="10.3.4" targetFramework="net461" />
-  <package id="NJsonSchema.CodeGeneration.TypeScript" version="10.3.4" targetFramework="net461" />
-  <package id="NJsonSchema.Yaml" version="10.3.4" targetFramework="net461" />
-  <package id="NSwag.Annotations" version="13.10.2" targetFramework="net461" />
-  <package id="NSwag.AssemblyLoader" version="13.10.2" targetFramework="net461" />
-  <package id="NSwag.CodeGeneration" version="13.10.2" targetFramework="net461" />
-  <package id="NSwag.CodeGeneration.CSharp" version="13.10.2" targetFramework="net461" />
-  <package id="NSwag.CodeGeneration.TypeScript" version="13.10.2" targetFramework="net461" />
-  <package id="NSwag.Commands" version="13.10.2" targetFramework="net461" />
-  <package id="NSwag.Core" version="13.10.2" targetFramework="net461" />
-  <package id="NSwag.Core.Yaml" version="13.10.2" targetFramework="net461" />
-  <package id="NSwag.Generation" version="13.10.2" targetFramework="net461" />
-  <package id="NSwag.Generation.AspNetCore" version="13.10.2" targetFramework="net461" />
-  <package id="NSwag.Generation.WebApi" version="13.10.2" targetFramework="net461" />
+  <package id="NJsonSchema" version="10.3.8" targetFramework="net461" />
+  <package id="NJsonSchema.CodeGeneration" version="10.3.8" targetFramework="net461" />
+  <package id="NJsonSchema.CodeGeneration.CSharp" version="10.3.8" targetFramework="net461" />
+  <package id="NJsonSchema.CodeGeneration.TypeScript" version="10.3.8" targetFramework="net461" />
+  <package id="NJsonSchema.Yaml" version="10.3.8" targetFramework="net461" />
+  <package id="NSwag.Annotations" version="13.10.6" targetFramework="net461" />
+  <package id="NSwag.AssemblyLoader" version="13.10.6" targetFramework="net461" />
+  <package id="NSwag.CodeGeneration" version="13.10.6" targetFramework="net461" />
+  <package id="NSwag.CodeGeneration.CSharp" version="13.10.6" targetFramework="net461" />
+  <package id="NSwag.CodeGeneration.TypeScript" version="13.10.6" targetFramework="net461" />
+  <package id="NSwag.Commands" version="13.10.6" targetFramework="net461" />
+  <package id="NSwag.Core" version="13.10.6" targetFramework="net461" />
+  <package id="NSwag.Core.Yaml" version="13.10.6" targetFramework="net461" />
+  <package id="NSwag.Generation" version="13.10.6" targetFramework="net461" />
+  <package id="NSwag.Generation.AspNetCore" version="13.10.6" targetFramework="net461" />
+  <package id="NSwag.Generation.WebApi" version="13.10.6" targetFramework="net461" />
   <package id="NSwag.SwaggerGeneration" version="12.3.1" targetFramework="net461" />
   <package id="NSwag.SwaggerGeneration.AspNetCore" version="12.3.1" targetFramework="net461" />
   <package id="NSwag.SwaggerGeneration.WebApi" version="12.3.1" targetFramework="net461" />


### PR DESCRIPTION
Dear Nikolay, my PR is here to ask you to upgrade to the most recent version of NJsonSchema.

The reason behind my request is: NJsonSchema v10.3.8 introduced a new property "SchemaTitle" on class `ClassTemplateModelBase` where the original title from the swagger definition is stored so that we can access it in the Class.liquid file. Previously there was no ability to get the completely "untouched" title from the schema within the Class.liquid template. (We need to generate custom attributes in the resulting models where we need that title).

NSwag and DotLiquid are also updated to the current versions because of dependencies from/to NJsonSchema.